### PR TITLE
Fix deprecation error

### DIFF
--- a/args.zig
+++ b/args.zig
@@ -1012,7 +1012,7 @@ pub fn printHelp(comptime Generic: type, name: []const u8, writer: anytype) !voi
                         try writer.print("      ", .{});
                 }
                 if (@hasDecl(Generic, "wrap_len")) {
-                    var it = std.mem.split(u8, @field(Generic.meta.option_docs, field.name), " ");
+                    var it = std.mem.splitScalar(u8, @field(Generic.meta.option_docs, field.name), ' ');
                     const threshold = Generic.wrap_len;
                     var line_len: usize = 0;
                     var newline = false;


### PR DESCRIPTION
Fixes:

```
zig-linux-x86_64-0.14.0-dev.61+04e08ea88/lib/std/mem.zig:2286:19: error: deprecated; use splitSequence, splitAny, or splitScalar
```