### PR TITLE
fix build for latest zig

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,6 @@
 .{
-    .name = "zig-args",
+    .name = .args,
+    .fingerprint = 0x161b2ea2aae2220a,
     .version = "0.0.0",
     .minimum_zig_version = "0.14.0-dev.2801+4d8c24c6c",
 


### PR DESCRIPTION
Hello,

There were breaking changes in `build.zig.zon` with zig master a couple of days:
* the name must be a enum literal. Since `zig-args` is an invalid enum literal, I changed it to `name` as recommended in the [documentation](https://github.com/ziglang/zig/blob/master/doc/build.zig.zon.md).
* the fingerprint is a new mandatory field, `zig build` generates one if it's not present in the file.

Changing the name is obviously a breaking change, users will have to change their build.zig file to use `args` instead of `zig-args`; I can change the name to whatever you want if you decide to go ahead with this PR.