### PR TITLE
Flush stderr's buffer when printing errors

### DIFF
--- a/args.zig
+++ b/args.zig
@@ -677,8 +677,9 @@ pub const ErrorHandling = union(enum) {
         switch (self) {
             .silent => return src_error,
             .print => {
-                var writer_buf: [2]u8 = undefined;
+                var writer_buf: [32]u8 = undefined;
                 var stderr = std.fs.File.stderr().writer(&writer_buf);
+                defer stderr.interface.flush() catch {};
                 try stderr.interface.print("{f}\n", .{err});
             },
             .collect => |collection| try collection.insert(err),

--- a/demo.zig
+++ b/demo.zig
@@ -57,8 +57,9 @@ pub fn main() !u8 {
         std.debug.print("\t'{s}'\n", .{arg});
     }
 
-    var writer_buf: [2]u8 = undefined;
+    var writer_buf: [128]u8 = undefined;
     var stdout = std.fs.File.stdout().writer(&writer_buf);
+    defer stdout.interface.flush() catch unreachable;
     try argsParser.printHelp(Options, options.executable_name orelse "demo", &stdout.interface);
     return 0;
 }


### PR DESCRIPTION
Hi,

I noticed than when using the `.print` error handling, the line feed would be missing from the message on stderr.
I found the reason to be an unflushed buffer.

Two solutions are possible, both tested to fix the observed symptom:
1. change the buffer size to be 0 to disable buffering
2. flush the buffer

This PR proposes the second option, let me know what you think.

Cheers,