### PR TITLE
Fix compilation for latest Zig

### DIFF
--- a/args.zig
+++ b/args.zig
@@ -1,5 +1,7 @@
 const std = @import("std");
 
+const ArrayList = std.array_list.Managed;
+
 /// Parses arguments for the given specification and our current process.
 /// - `Spec` is the configuration of the arguments.
 /// - `allocator` is the allocator that is used to allocate all required memory
@@ -110,7 +112,7 @@ fn parseInternal(
     errdefer result.arena.deinit();
     var result_arena_allocator = result.arena.allocator();
 
-    var arglist = std.ArrayList([:0]const u8).init(allocator);
+    var arglist: ArrayList([:0]const u8) = .init(allocator);
     defer arglist.deinit();
 
     var last_error: ?anyerror = null;
@@ -565,12 +567,12 @@ pub const ErrorCollection = struct {
     const Self = @This();
 
     arena: std.heap.ArenaAllocator,
-    list: std.ArrayList(Error),
+    list: ArrayList(Error),
 
     pub fn init(allocator: std.mem.Allocator) Self {
         return Self{
-            .arena = std.heap.ArenaAllocator.init(allocator),
-            .list = std.ArrayList(Error).init(allocator),
+            .arena = .init(allocator),
+            .list = .init(allocator),
         };
     }
 
@@ -1128,7 +1130,7 @@ test "full help" {
         };
     };
 
-    var test_buffer = std.ArrayList(u8).init(std.testing.allocator);
+    var test_buffer: ArrayList(u8) = .init(std.testing.allocator);
     defer test_buffer.deinit();
     var new_writer = test_buffer.writer().adaptToNewApi();
 
@@ -1166,7 +1168,7 @@ test "help with no usage summary" {
         };
     };
 
-    var test_buffer = std.ArrayList(u8).init(std.testing.allocator);
+    var test_buffer: ArrayList(u8) = .init(std.testing.allocator);
     defer test_buffer.deinit();
 
     var new_writer = test_buffer.writer().adaptToNewApi();
@@ -1206,7 +1208,7 @@ test "help with wrapping" {
         };
     };
 
-    var test_buffer = std.ArrayList(u8).init(std.testing.allocator);
+    var test_buffer: ArrayList(u8) = .init(std.testing.allocator);
     defer test_buffer.deinit();
 
     var new_writer = test_buffer.writer().adaptToNewApi();

--- a/args.zig
+++ b/args.zig
@@ -1130,11 +1130,10 @@ test "full help" {
         };
     };
 
-    var test_buffer: ArrayList(u8) = .init(std.testing.allocator);
-    defer test_buffer.deinit();
-    var new_writer = test_buffer.writer().adaptToNewApi();
+    var buffer: std.Io.Writer.Allocating = .init(std.testing.allocator);
+    defer buffer.deinit();
 
-    try printHelp(Options, "test", &new_writer.new_interface);
+    try printHelp(Options, "test", &buffer.writer);
 
     const expected =
         \\Usage: test [--boolflag] [--stringflag]
@@ -1147,7 +1146,7 @@ test "full help" {
         \\
     ;
 
-    try std.testing.expectEqualStrings(expected, test_buffer.items);
+    try std.testing.expectEqualStrings(expected, buffer.written());
 }
 
 test "help with no usage summary" {
@@ -1168,11 +1167,10 @@ test "help with no usage summary" {
         };
     };
 
-    var test_buffer: ArrayList(u8) = .init(std.testing.allocator);
+    var test_buffer: std.Io.Writer.Allocating = .init(std.testing.allocator);
     defer test_buffer.deinit();
 
-    var new_writer = test_buffer.writer().adaptToNewApi();
-    try printHelp(Options, "test", &new_writer.new_interface);
+    try printHelp(Options, "test", &test_buffer.writer);
 
     const expected =
         \\Usage: test
@@ -1185,7 +1183,7 @@ test "help with no usage summary" {
         \\
     ;
 
-    try std.testing.expectEqualStrings(expected, test_buffer.items);
+    try std.testing.expectEqualStrings(expected, test_buffer.written());
 }
 
 test "help with wrapping" {
@@ -1208,11 +1206,10 @@ test "help with wrapping" {
         };
     };
 
-    var test_buffer: ArrayList(u8) = .init(std.testing.allocator);
+    var test_buffer: std.Io.Writer.Allocating = .init(std.testing.allocator);
     defer test_buffer.deinit();
 
-    var new_writer = test_buffer.writer().adaptToNewApi();
-    try printHelp(Options, "test", &new_writer.new_interface);
+    try printHelp(Options, "test", &test_buffer.writer);
 
     const expected =
         \\Usage: test
@@ -1231,5 +1228,5 @@ test "help with wrapping" {
         \\
     ;
 
-    try std.testing.expectEqualStrings(expected, test_buffer.items);
+    try std.testing.expectEqualStrings(expected, test_buffer.written());
 }


### PR DESCRIPTION
1. ArrayList is now unmanaged by default, use the managed version explicitly
2. the `GenericWriter.toNewApi()` now wants a buffer as argument. switch to `std.Io.Writer.Allocating` instead